### PR TITLE
Catch irregular slashes in page-data.json links

### DIFF
--- a/src/fake-data.spec.ts
+++ b/src/fake-data.spec.ts
@@ -187,6 +187,19 @@ export const headComponentsData = [
       crossOrigin: 'use-credentials'
     },
     _owner: null
+  },
+  { // 17
+    type: 'link',
+    key: '/page-data\\index\\app-data.json',
+    ref: null,
+    props:
+    {
+      as: 'fetch',
+      rel: 'preload',
+      href: '/page-data\\index\\app-data.json',
+      crossOrigin: 'use-credentials'
+    },
+    _owner: null
   }
 ]
 

--- a/src/fake-data.spec.ts
+++ b/src/fake-data.spec.ts
@@ -174,6 +174,19 @@ export const headComponentsData = [
       crossOrigin: 'use-credentials'
     },
     _owner: null
+  },
+  { // 16
+    type: 'link',
+    key: '/page-data\\index\\page-data.json',
+    ref: null,
+    props:
+    {
+      as: 'fetch',
+      rel: 'preload',
+      href: '/page-data\\index\\page-data.json',
+      crossOrigin: 'use-credentials'
+    },
+    _owner: null
   }
 ]
 

--- a/src/gatsby-ssr.spec.ts
+++ b/src/gatsby-ssr.spec.ts
@@ -60,7 +60,7 @@ describe('gatsby-ssr.js', (): void => {
 
       onRenderBody({ scripts: [] })
       function getHeadComponents (): ReactNode[] {
-        return [headComponentsData[0], headComponentsData[1], headComponentsData[14], headComponentsData[15], headComponentsData[16]]
+        return [headComponentsData[0], headComponentsData[1], headComponentsData[14], headComponentsData[15], headComponentsData[16], headComponentsData[17]]
       }
       function getPostBodyComponents (): ReactNode[] {
         return []

--- a/src/gatsby-ssr.spec.ts
+++ b/src/gatsby-ssr.spec.ts
@@ -60,7 +60,7 @@ describe('gatsby-ssr.js', (): void => {
 
       onRenderBody({ scripts: [] })
       function getHeadComponents (): ReactNode[] {
-        return [headComponentsData[0], headComponentsData[1], headComponentsData[14], headComponentsData[15]]
+        return [headComponentsData[0], headComponentsData[1], headComponentsData[14], headComponentsData[15], headComponentsData[16]]
       }
       function getPostBodyComponents (): ReactNode[] {
         return []

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode } from 'react'
-import { checkPathExclusion } from './utilities'
+import { checkPathExclusion, isChildOfDirectory } from './utilities'
 
 export interface OnRenderBodyArgs {
   scripts?: Script[]
@@ -66,8 +66,8 @@ function getHeadComponentsNoJS (headComponents: ReactNode[], pluginOptions: Plug
     }
 
     // Gatsby puts JSON files in the head that should also be removed if javascript is removed, all these Gatsby files are in the
-    // "/static" or /page-data directories.
-    if (headComponent.props.href && (headComponent.props.href.startsWith('/static/') || headComponent.props.href.endsWith('page-data.json'))) {
+    // "/static" or "/page-data" directories.
+    if (headComponent.props.href && (isChildOfDirectory('/static', headComponent.props.href) || isChildOfDirectory('/page-data', headComponent.props.href))) {
       return false
     }
 

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -67,7 +67,7 @@ function getHeadComponentsNoJS (headComponents: ReactNode[], pluginOptions: Plug
 
     // Gatsby puts JSON files in the head that should also be removed if javascript is removed, all these Gatsby files are in the
     // "/static" or /page-data directories.
-    if (headComponent.props.href && (headComponent.props.href.startsWith('/static/') || headComponent.props.href.startsWith('/page-data/'))) {
+    if (headComponent.props.href && (headComponent.props.href.startsWith('/static/') || headComponent.props.href.endsWith('page-data.json'))) {
       return false
     }
 

--- a/src/utilities.spec.ts
+++ b/src/utilities.spec.ts
@@ -1,4 +1,4 @@
-import { checkPathExclusion } from './utilities'
+import { checkPathExclusion, isChildOfDirectory } from './utilities'
 
 describe('checkPathExclusion', (): void => {
   it('does the pathname match any of the exclusions', (): void => {
@@ -7,5 +7,16 @@ describe('checkPathExclusion', (): void => {
     expect(checkPathExclusion('/about/blerns', { excludePaths: /(\/client)|(\/tacos)/ })).toBeFalsy()
     expect(checkPathExclusion('/about/tacos', { excludePaths: /(\/client)|(\/about\/tacos)/ })).toBeTruthy()
     expect(checkPathExclusion('/blerkstorm', {})).toBeFalsy()
+  })
+})
+
+describe('isChildOfDirectory', (): void => {
+  it('checks if a pathname is a child of a dirname', (): void => {
+    expect(isChildOfDirectory('/foo', '/foo')).toBeFalsy()
+    expect(isChildOfDirectory('/static', '/static/a-file.json')).toBeTruthy()
+    expect(isChildOfDirectory('/static', '/static/dir/another-file.png')).toBeTruthy()
+    expect(isChildOfDirectory('/page-data', '/page-data/index/page-data.json')).toBeTruthy()
+    expect(isChildOfDirectory('/page-data', '/page-data/index/app-data.json')).toBeTruthy()
+    expect(isChildOfDirectory('/page-data', '/page-data\\index\\page-data.json')).toBeTruthy()
   })
 })

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,5 @@
 import { PluginOptions } from './gatsby-ssr'
-import { relative, isAbsolute } from 'path';
+import { relative, isAbsolute } from 'path'
 
 export function checkPathExclusion (pathname: string, pluginOptions: PluginOptions): boolean {
   if (!pluginOptions.excludePaths) return false
@@ -11,6 +11,6 @@ export function checkPathExclusion (pathname: string, pluginOptions: PluginOptio
  * Checks if a given pathname is a child of a given dirname
  */
 export function isChildOfDirectory (dirname: string, pathname: string): boolean {
-  const resolution = relative(dirname, pathname);
-  return !!(resolution && !resolution.startsWith('..') && !isAbsolute(resolution));
+  const resolution = relative(dirname, pathname)
+  return !!(resolution && !resolution.startsWith('..') && !isAbsolute(resolution))
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,16 @@
 import { PluginOptions } from './gatsby-ssr'
+import { relative, isAbsolute } from 'path';
 
 export function checkPathExclusion (pathname: string, pluginOptions: PluginOptions): boolean {
   if (!pluginOptions.excludePaths) return false
 
   return RegExp(pluginOptions.excludePaths).test(pathname)
+}
+
+/**
+ * Checks if a given pathname is a child of a given dirname
+ */
+export function isChildOfDirectory (dirname: string, pathname: string): boolean {
+  const resolution = relative(dirname, pathname);
+  return !!(resolution && !resolution.startsWith('..') && !isAbsolute(resolution));
 }


### PR DESCRIPTION
## Summary
Addresses what appears to be an environmental bug within Gatsby JS that causes `page-data.json` files to be referenced via a link containing irregular slashes, such as `<link as="fetch" rel="preload" href="/page-data\index\page-data.json" crossorigin="anonymous"/>`.

## Linked Issues
 - Closes [issue #15](https://github.com/itmayziii/gatsby-plugin-no-javascript/issues/15).

## Note
 - Additionally, this issue is referenced in [this](https://henrique.codes/speed-up-gatsby-site/) blog post, as they seem to have a similar issue with the formatting of slashes in their `page-data.json` href too.
