### PR TITLE
Remove the infamous "_gatsby-scripts"

### DIFF
--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -94,6 +94,14 @@ function getPostBodyComponentsNoJS (postBodyComponents: ReactNode[], pluginOptio
     if (postBodyComponent.props.id && (postBodyComponent.props.id === 'gatsby-script-loader' || postBodyComponent.props.id === 'gatsby-chunk-mapping')) {
       return false
     }
+    
+    // Remove the infamous "_gatsby-scripts", introduced in Gatsby 5.2.0
+    if (
+        postBodyComponent.props.sliceId &&
+        postBodyComponent.props.sliceId === "_gatsby-scripts"
+    ) {
+        return false
+    }
 
     return pageScripts.find((script): boolean => postBodyComponent.type === 'script' && `/${script.name}` === postBodyComponent.props.src) === undefined
   })

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -98,7 +98,7 @@ function getPostBodyComponentsNoJS (postBodyComponents: ReactNode[], pluginOptio
     // Remove the infamous "_gatsby-scripts", introduced in Gatsby 5.2.0
     if (
         postBodyComponent.props.sliceId &&
-        postBodyComponent.props.sliceId === "_gatsby-scripts"
+        postBodyComponent.props.sliceId === '_gatsby-scripts'
     ) {
         return false
     }


### PR DESCRIPTION
Remove the infamous "_gatsby-scripts", introduced in Gatsby 5.2.0

## Summary

Remove the infamous "_gatsby-scripts" slices, introduced in Gatsby 5.2.0

## Linked Issues
# https://github.com/itmayziii/gatsby-plugin-no-javascript/issues/36
